### PR TITLE
STM CI: Changed branch to stm-develop1 and updated title

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,9 +6,9 @@ name: Build
 # events but only for the main branch
 on:
   push:
-    branches: [ stm-develop ]
+    branches: [ stm-develop1 ]
   pull_request:
-    branches: [ stm-develop ]
+    branches: [ stm-develop1 ]
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:


### PR DESCRIPTION
This is necessary because the GitHub workflows need to be on the branch they run on and *not* on `main`. Lesson learned.